### PR TITLE
Provide required properties to can_action* methods.

### DIFF
--- a/lib/QBit/Application/Model/Multistate/DB.pm
+++ b/lib/QBit/Application/Model/Multistate/DB.pm
@@ -19,7 +19,11 @@ __PACKAGE__->abstract_methods(
 sub check_action {
     my ($self, $object, $action) = @_;
 
-    $object = $self->_get_object_fields($object, ['multistate']);
+    my @actions_depends_on_db_fields = do {
+        my $fields = $self->_get_fields_obj(['actions'])->get_fields();
+        grep {$fields->{$_}->{'db'} && $_ ne 'actions'} keys %$fields;
+    };
+    $object = $self->_get_object_fields($object, ['multistate', @actions_depends_on_db_fields]);
 
     throw Exception::Multistate::NotFound unless defined($object);
 


### PR DESCRIPTION
actions dbmanager model field can be dependant on other fields. If the
fields are required in can_action\* method they will not provided there
and the code will be broken. The change provides the required (only db)
fields to the can_action\* methods.
